### PR TITLE
Attached popups to the maui window at PushPopup navigation

### DIFF
--- a/src/UXDivers.Popups.Maui/PopupPage.cs
+++ b/src/UXDivers.Popups.Maui/PopupPage.cs
@@ -191,7 +191,7 @@ namespace UXDivers.Popups.Maui
 
         /// <summary>
         /// Gets or sets the corner radius of the popup.
-        /// Default <see cref="CornerRadius" default />
+        /// Default is <see cref="CornerRadius"/> default value.
         /// </summary>
         public CornerRadius PopupCornerRadius
         {
@@ -238,8 +238,8 @@ namespace UXDivers.Popups.Maui
         }
 
         /// <summary>
-        /// Bindable property for specifying popup border brush.
-        /// Default <see cref="Thickness" default />
+        /// Bindable property for specifying popup border thickness.
+        /// Default is <see cref="Thickness"/> default value.
         /// </summary>
         public static readonly BindableProperty PopupBorderThicknessProperty = BindableProperty.Create(
             nameof(PopupBorderThickness),

--- a/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.cs
+++ b/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.cs
@@ -54,7 +54,7 @@ internal partial class NativePopupManager : INativePopupManager
                 throw new NullReferenceException("Application.Current or its windows are not properly initialized");
             }
 
-            popupPage.Parent = Application.Current?.Windows[0];
+            popupPage.Parent = Application.Current.Windows[0];
 
             return ShowNativeViewAsync(popupPage);
         }


### PR DESCRIPTION
We attached the popups to the maui windows at PushPopup navigation to link the popups with the maui visual tree in order to make some features like the AppThemeBinding works.