### PR TITLE
Fixed stack overflow issue on windows

### DIFF
--- a/src/UXDivers.Popups.Maui.DemoApp/UXDivers.Popups.Maui.DemoApp.csproj
+++ b/src/UXDivers.Popups.Maui.DemoApp/UXDivers.Popups.Maui.DemoApp.csproj
@@ -53,12 +53,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\UXDivers.Popups\UXDivers.Popups.csproj" />
+		<ProjectReference Include="..\UXDivers.Popups\UXDivers.Popups.csproj" />
         <ProjectReference Include="..\UXDivers.Popups.Maui\UXDivers.Popups.Maui.csproj" />
     </ItemGroup>
 </Project>

--- a/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.cs
+++ b/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.cs
@@ -56,13 +56,21 @@ internal partial class NativePopupManager : INativePopupManager
 
             popupPage.Parent = Application.Current.Windows[0];
 
-            return ShowNativeViewAsync(popupPage);
+            return ShowPlatformNativeViewAsync(popupPage);
         }
         
         throw new ArgumentException("The provided popup does not inherit from PopupPage", nameof(popup));
     }
 
 #if !(ANDROID || IOS || WINDOWS || MACCATALYST)
+    // Fallback implementation for non-platform targets. Always thrown for non-platform targets.
+    private Task<object> ShowPlatformNativeViewAsync(PopupPage popup)
+    {
+        throw new PlatformNotSupportedException(
+            "Native popup operations require a platform-specific target framework (e.g. net10.0-android, net10.0-ios, net10.0-windows)."
+        );
+    }
+
     // Fallback implementation for non-platform targets. Always thrown for non-platform targets.
     public Task CloseNativeViewAsync(object nativePopup)
     {

--- a/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.droid.cs
+++ b/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.droid.cs
@@ -16,7 +16,7 @@ internal partial class NativePopupManager
     /// <param name="popup">The popup page to display.</param>
     /// <returns>A Task that resolves with the native view object.</returns>
     /// <exception cref="NullReferenceException">Thrown if the root view or native view is invalid.</exception>
-    public Task<object> ShowNativeViewAsync(PopupPage popup)
+    private Task<object> ShowPlatformNativeViewAsync(PopupPage popup)
     {
         if (popup == null)
         {

--- a/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.ios.cs
+++ b/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.ios.cs
@@ -16,7 +16,7 @@ internal partial class NativePopupManager
     /// <param name="popup">The popup page to display.</param>
     /// <returns>A Task that resolves with the native view object.</returns>
     /// <exception cref="ArgumentException">Thrown if the popup cannot be converted to a native view.</exception>
-    public Task<object> ShowNativeViewAsync(PopupPage popup)
+    private Task<object> ShowPlatformNativeViewAsync(PopupPage popup)
     {
         var mauiContext = GetMauiContext();
 

--- a/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.win.cs
+++ b/src/UXDivers.Popups.Maui/Services/NativePopupManager/NativePopupManager.win.cs
@@ -16,7 +16,7 @@ internal partial class NativePopupManager
     /// <param name="popupPage">The popup page to display.</param>
     /// <returns>A Task that resolves with the native view object.</returns>
     /// <exception cref="ArgumentException">Thrown if the popup cannot be converted to a native view.</exception>
-    public async Task<object> ShowNativeViewAsync(PopupPage popupPage)
+    private async Task<object> ShowPlatformNativeViewAsync(PopupPage popupPage)
     {
         ArgumentNullException.ThrowIfNull(popupPage);
 

--- a/src/UXDivers.Popups.Maui/UXDivers.Popups.Maui.csproj
+++ b/src/UXDivers.Popups.Maui/UXDivers.Popups.Maui.csproj
@@ -11,7 +11,7 @@
 
 		<!-- Nuget -->
         <PackageId>UXDivers.Popups.Maui</PackageId>
-        <Version>0.9.2</Version>
+        <Version>0.9.3</Version>
         <Authors>UXDivers</Authors>
         <Company>UXDivers</Company>
         <Summary>A comprehensive popup controls library for .NET MAUI featuring 9 ready-to-use components (Toast, ActionSheets, Forms, Modals, and more), 10+ smooth animations, full MVVM support with dependency injection, dark/light theming, and cross-platform compatibility for iOS, Android, Windows, and Mac Catalyst.</Summary>


### PR DESCRIPTION
Renames the native platform popup display method to ShowPlatformNativeViewAsync, adds an exception when no platform-specific implementation is available for that method, fixes #31, and updates the version to 0.9.3.