### PR TITLE
Add Property to prevent dismissing a specific Popup via Back Button

### DIFF
--- a/src/UXDivers.Popups.Maui.DemoApp/PlaygroundPage.xaml
+++ b/src/UXDivers.Popups.Maui.DemoApp/PlaygroundPage.xaml
@@ -144,6 +144,12 @@
                     x:Name="closeOnBackgroundClicked"
                     PropertyName="Close when tap outside"
                 />
+                
+                <!-- Property Card -->
+                <local:SwitchTemplate
+                    x:Name="preventBackButtonDismiss"
+                    PropertyName="Prevent Back Button dismiss"
+                />
 
                 <!-- Property Card -->
                 <local:SwitchTemplate

--- a/src/UXDivers.Popups.Maui.DemoApp/PlaygroundPage.xaml.cs
+++ b/src/UXDivers.Popups.Maui.DemoApp/PlaygroundPage.xaml.cs
@@ -72,6 +72,7 @@ public partial class PlaygroundPage : PopupPage
             AppearingAnimation = appearing,
             DisappearingAnimation = disappearing,
             CloseWhenBackgroundIsClicked = closeOnBackgroundClicked.IsToggled,
+            PreventBackButtonDismiss = preventBackButtonDismiss.IsToggled,
             BackgroundInputTransparent = backgroundInputTransparent.IsToggled,
             BackgroundOpacity = overlayOpacity.Value / 100,
             CloseButtonIconText = MaterialSymbolsFont.Close,

--- a/src/UXDivers.Popups.Maui/Helpers/HostBuilderExtensions.droid.cs
+++ b/src/UXDivers.Popups.Maui/Helpers/HostBuilderExtensions.droid.cs
@@ -51,6 +51,14 @@ public static partial class HostBuilderExtensions
             // If there is a popup, close it and consume Back
             if (stack.Count > 0)
             {
+                var topPopup = stack[stack.Count - 1];
+
+                // If the topmost popup prevents back button dismiss, consume the back press without closing
+                if (topPopup.PreventBackButtonDismiss)
+                {
+                    return;
+                }
+
                 _ = IPopupService.Current.PopAsync();
                 return;
             }

--- a/src/UXDivers.Popups.Maui/PopupPage.cs
+++ b/src/UXDivers.Popups.Maui/PopupPage.cs
@@ -276,6 +276,27 @@ namespace UXDivers.Popups.Maui
         }
 
         /// <summary>
+        /// Bindable property indicating whether the popup should prevent being dismissed by the Android back button.
+        /// </summary>
+        public static readonly BindableProperty PreventBackButtonDismissProperty = BindableProperty.Create(
+            nameof(PreventBackButtonDismiss),
+            typeof(bool),
+            typeof(PopupPage),
+            false);
+
+        /// <summary>
+        /// Gets or sets whether the popup should prevent being dismissed by the Android back button.
+        /// When true, the popup will not be closed when the user presses the back button on Android,
+        /// even if the global <c>closePopupOnBackAndroid</c> option is enabled.
+        /// Default is false.
+        /// </summary>
+        public bool PreventBackButtonDismiss
+        {
+            get => (bool)GetValue(PreventBackButtonDismissProperty);
+            set => SetValue(PreventBackButtonDismissProperty, value);
+        }
+
+        /// <summary>
         /// Gets or sets the content of the popup page.
         /// </summary>
         public View? PopupContent

--- a/src/UXDivers.Popups/Controls/IPopupPage.cs
+++ b/src/UXDivers.Popups/Controls/IPopupPage.cs
@@ -33,6 +33,13 @@ public interface IPopupPage
     bool DisableWhenIsAnimating { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the popup should prevent being dismissed by the Android back button.
+    /// When true, the popup will not be closed when the user presses the back button on Android,
+    /// even if the global <c>closePopupOnBackAndroid</c> option is enabled.
+    /// </summary>
+    bool PreventBackButtonDismiss { get; }
+
+    /// <summary>
     /// Gets the command to execute when the background is clicked.
     /// </summary>
     ICommand BackgroundClickedCommand { get; }


### PR DESCRIPTION
Adds the Property `PreventBackButtonDismiss` to `IPopupPage` in order to be able to prevent specific Popups (e.g. Loading Indicator Popus) from being dismissed via Android Back Button even when Backbutton dismiss is globally enabled.